### PR TITLE
Option to control fire spread speed

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -2,6 +2,13 @@ if settings.startup["Noxys_Trees-tree_dying_factor"].value > 0.00001 then
 	data.raw.fire["fire-flame-on-tree"].tree_dying_factor = settings.startup["Noxys_Trees-tree_dying_factor"].value
 end
 
+if settings.startup["Noxys_Trees-tree_fire_spread_speed_factor"].value ~= 1.0 then
+	local val = settings.startup["Noxys_Trees-tree_fire_spread_speed_factor"].value
+	local f = data.raw.fire["fire-flame-on-tree"]
+	f.spread_delay = f.spread_delay / val
+	f.spread_delay_deviation = f.spread_delay_deviation / val
+end
+
 asd = dsa
  
 local mul = settings.startup["Noxys_Trees-emission_multiplier"].value

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,5 +1,6 @@
 [mod-setting-name]
 Noxys_Trees-tree_dying_factor=Tree dying factor from fire
+Noxys_Trees-tree_fire_spread_speed_factor=Forest fire spread factor
 Noxys_Trees-emission_multiplier=Emmision multiplier
 Noxys_Trees-enabled=Enabled
 Noxys_Trees-debug=Debug mode
@@ -25,6 +26,7 @@ Noxys_Trees-surfaces=Surfaces
 
 [mod-setting-description]
 Noxys_Trees-tree_dying_factor=Percentage of how many trees should be removed after they've been burnt by fire.\nVanilla default is 0.8 (80%).\n\nSet this to 0 to not alter this behavior.
+Noxys_Trees-tree_fire_spread_speed_factor=Multiplier of speed with which forest fires spread.
 Noxys_Trees-emission_multiplier=A multiplier of how much pollution is consumes by trees.
 Noxys_Trees-enabled=When enabled trees will spread and die.
 Noxys_Trees-debug=Enables the output of debug messages.

--- a/settings.lua
+++ b/settings.lua
@@ -11,6 +11,15 @@ data:extend({
 	},
 	{
 		type = "double-setting",
+		name = "Noxys_Trees-tree_fire_spread_speed_factor",
+		setting_type = "startup",
+		minimum_value = 0.0001,
+		default_value = 1.0,
+		maximum_value = 10.0,
+		order = "b",
+	},
+	{
+		type = "double-setting",
 		name = "Noxys_Trees-emission_multiplier",
 		setting_type = "startup",
 		default_value = 1,


### PR DESCRIPTION
Hi,

I'm using this mod as a base for an idea of a forest-as-an-enemy modpack and figured out I'll make PRs out of one or two tweaks I think are generally useful. This one tweaks forest fire spread speed. I verified that low values slow down or stop fire from spreading altogether.